### PR TITLE
fix: propagate the stack trace when using customErrorInstance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jokr-services/logr",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jokr-services/logr",
-      "version": "2.7.0",
+      "version": "2.7.1",
       "license": "MIT",
       "dependencies": {
         "dd-trace": "^4.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jokr-services/logr",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "main": "index.js",
   "types": "*/**/*.d.ts",
   "license": "MIT",

--- a/src/lib/core/factories/catch-exception/catch-exception.factory.ts
+++ b/src/lib/core/factories/catch-exception/catch-exception.factory.ts
@@ -35,11 +35,18 @@ export function catchExceptionFactory(
         }
 
         if (!!options?.customErrorInstance) {
+          let newErr: any;
           if (typeof options?.customErrorInstance === 'function') {
-            throw options.customErrorInstance.call(this, e, this, ...args);
+            newErr = options.customErrorInstance.call(this, e, this, ...args);
+          } else {
+            newErr = options.customErrorInstance;
           }
 
-          throw options.customErrorInstance;
+          const stackTraceHead = newErr.stack.split('\n').slice(0, 2).join('\n');
+          const originalStackTrace = (e as any).stack;
+          newErr.stack = stackTraceHead + '\n' + originalStackTrace;
+
+          throw newErr;
         }
 
         if (options?.bubbleException || options?.typeErrorHandling === 'REGISTER') {
@@ -76,11 +83,18 @@ export function catchExceptionFactory(
         }
 
         if (!!options?.customErrorInstance) {
+          let newErr: any;
           if (typeof options?.customErrorInstance === 'function') {
-            throw options.customErrorInstance.call(this, e, this, ...args);
+            newErr = options.customErrorInstance.call(this, e, this, ...args);
+          } else {
+            newErr = options.customErrorInstance;
           }
 
-          throw options.customErrorInstance;
+          const stackTraceHead = newErr.stack.split('\n').slice(0, 2).join('\n');
+          const originalStackTrace = (e as any).stack;
+          newErr.stack = stackTraceHead + '\n' + originalStackTrace;
+
+          throw newErr;
         }
 
         if (options?.bubbleException || options?.typeErrorHandling === 'REGISTER') {


### PR DESCRIPTION
## Description

Quando usamos a opção `customErrorInstance`, toda a stack trace atual é sobrescrita, o que dificulta o debug. Este PR corrige esse problema concatenando a stack trace do erro original com as informações principais da stack trace fornecida pelo `customErrorInstance`


## Screenshots

**Antes**
![image](https://github.com/user-attachments/assets/872d306b-7232-4630-8297-d7b091a3a783)

**Depois**
![image](https://github.com/user-attachments/assets/e94d38a1-bb5d-4e18-bda3-4394f0710d2a)

**Exemplo**
![image](https://github.com/user-attachments/assets/b45c2912-14e8-4b19-a7ca-cee82a3dea7f)

## Checklist

- [x] My code follows the project's coding guidelines.
- [x] I have tested my changes thoroughly.
- [ ] I have updated the project documentation if necessary.
- [ ] I have added comments or documentation to explain complex parts of the code.
- [x] All existing tests pass successfully.

## Additional Notes

Como o intuito do `customErrorInstance` é apenas trocar a instância do erro, estou pegando apenas as duas primeiras linhas da stack trace (`newErr.stack.split('\n').slice(0, 2).join('\n')`), que são suficientes para identificarmos onde o `customErrorInstance` está sendo chamado.